### PR TITLE
Issue 42 - Generic solution for filtering over relationships

### DIFF
--- a/graphene_sqlalchemy_filter/filters.py
+++ b/graphene_sqlalchemy_filter/filters.py
@@ -792,7 +792,6 @@ class FilterSet(graphene.InputObjectType):
             model=cls.model,
             parent_attr=None
         )
-        print(result)
         if not isinstance(result["__root__"], dict):
             return query.filter(result["__root__"])
         else:

--- a/graphene_sqlalchemy_filter/filters.py
+++ b/graphene_sqlalchemy_filter/filters.py
@@ -21,7 +21,9 @@ from sqlalchemy.exc import SAWarning
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.attributes import InstrumentedAttribute
+from sqlalchemy.orm.properties import ColumnProperty
 from sqlalchemy.orm.query import Query
+from sqlalchemy.orm.relationships import RelationshipProperty
 from sqlalchemy.sql import sqltypes
 
 
@@ -495,10 +497,10 @@ class FilterSet(graphene.InputObjectType):
 
     @classmethod
     def _generate_default_filters(
-        cls, model, field_filters: 'Dict[str, Union[Iterable[str], Any]]'
-    ) -> dict:
+            cls, model,
+            field_filters: 'Dict[str, Union[Iterable[str], Any]]') -> dict:
         """
-        Generate GraphQL fields from SQLAlchemy model columns.
+        Generate GraphQL fields from SQLAlchemy model columns and relationships.
 
         Args:
             model: SQLAlchemy model.
@@ -510,47 +512,16 @@ class FilterSet(graphene.InputObjectType):
 
         """
         graphql_filters = {}
-        filters_map = cls.ALLOWED_FILTERS
-        model_fields = cls._get_model_fields_data(model, field_filters.keys())
-
-        for field_name, field_object in model_fields.items():
-            column_type = field_object['type']
-
-            expressions = field_filters[field_name]
-            if expressions == cls.ALL:
-                if column_type is None:
-                    raise ValueError(
-                        'Unsupported field type for automatic filter binding'
-                    )
-
-                type_class = column_type.__class__
-                try:
-                    expressions = filters_map[type_class].copy()
-                except KeyError:
-                    for type_, exprs in filters_map.items():
-                        if issubclass(type_class, type_):
-                            expressions = exprs.copy()
-                            break
-                    else:
-                        raise KeyError(
-                            'Unsupported column type. '
-                            'Hint: use EXTRA_ALLOWED_FILTERS.'
-                        )
-
-                if field_object['nullable']:
-                    expressions.append(cls.IS_NULL)
-
-            field_type = cls._get_gql_type_from_sqla_type(
-                column_type, field_object['column']
-            )
-
-            fields = cls._generate_filter_fields(
-                expressions, field_name, field_type, field_object['nullable']
-            )
-            for name, field in fields.items():
-                graphql_filters[name] = get_field_as(
-                    field, graphene.InputField
-                )
+        fields = cls._recursively_generate_filters(
+            model=model,
+            fields={},
+            parent_field=None,
+            parent=None,
+            field_filters=field_filters,
+            parents=[]
+        )
+        for name, field in fields.items():
+            graphql_filters[name] = get_field_as(field, graphene.InputField)
 
         return graphql_filters
 
@@ -606,7 +577,7 @@ class FilterSet(graphene.InputObjectType):
                     'nullable': True,
                 }
 
-            elif isinstance(descr, InstrumentedAttribute):
+            elif isinstance(descr.property, ColumnProperty):
                 attr = descr.property
                 name = attr.key
                 if name not in only_fields:
@@ -617,6 +588,16 @@ class FilterSet(graphene.InputObjectType):
                     'column': column,
                     'type': column.type,
                     'nullable': column.nullable,
+                }
+
+            elif isinstance(descr.property, RelationshipProperty):
+                attr = descr.property
+                name = attr.key
+                if name not in only_fields:
+                    continue
+                model_fields[name] = {
+                    'column': attr,
+                    'type': 'relationship'
                 }
 
         return model_fields
@@ -667,6 +648,107 @@ class FilterSet(graphene.InputObjectType):
         return filters
 
     @classmethod
+    def _recursively_generate_filters(
+        cls,
+        model: 'sqlalchemy.ext.declarative.api.DeclarativeMeta',
+        fields: dict,
+        parent_field: 'Union[String, None]',
+        parent: 'Union[dict, None]',
+        field_filters: dict,
+        parents: 'List[String]'
+    ) -> dict:
+        """
+        Recursively geenerate filters from the given fields.
+
+        Args:
+            model: The model.
+            fields: Holds the resulting filters.
+            parent_field: The parent field name.
+            parent: Parent for the resulting fields.
+            field_filters: The fields to turn into filters.
+            parents: List of parent fields to create unique type names.
+
+        Returns:
+            Dict.
+
+        """
+        model_fields = cls._get_model_fields_data(model, field_filters.keys())
+        filters_map = cls.ALLOWED_FILTERS
+
+        for field_name, field_object in model_fields.items():
+            column_type = field_object['type']
+            if column_type == 'relationship':
+                rel_model = field_object['column'].mapper.class_
+                fields[field_name] = {}
+                cls._recursively_generate_filters(
+                    model=rel_model,
+                    fields=fields[field_name],
+                    parent_field=field_name,
+                    parent=fields,
+                    field_filters=field_filters[field_name],
+                    parents=parents + [field_name]
+                )
+                continue
+
+            expressions = field_filters[field_name]
+            if expressions == cls.ALL:
+                if column_type is None:
+                    raise ValueError(
+                        'Unsupported field type for automatic filter binding'
+                    )
+
+                type_class = column_type.__class__
+                try:
+                    expressions = filters_map[type_class].copy()
+                except KeyError:
+                    for type_, exprs in filters_map.items():
+                        if issubclass(type_class, type_):
+                            expressions = exprs.copy()
+                            break
+                    else:
+                        raise KeyError(
+                            'Unsupported column type. '
+                            'Hint: use EXTRA_ALLOWED_FILTERS.'
+                        )
+
+                if field_object['nullable']:
+                    expressions.append(cls.IS_NULL)
+
+            field_type = cls._get_gql_type_from_sqla_type(
+                column_type, field_object['column']
+            )
+
+            fields.update(
+                cls._generate_filter_fields(
+                    expressions, field_name, field_type, field_object['nullable']
+                )
+            )
+
+        # Create a graphene type from this level
+        if parent is not None:
+            filters = {}
+            for name, field in fields.items():
+                filters[name] = get_field_as(field, graphene.InputField)
+
+            for op in [cls.AND, cls.OR, cls.NOT]:
+                doc = cls.DESCRIPTIONS.get(op)
+                graphql_name = cls.GRAPHQL_EXPRESSION_NAMES[op]
+
+                # Need to concatenate to keep the types unique
+                OperatorAutoType = type(
+                    "_".join(parents + [op]), (graphene.InputObjectType, ), filters)
+                filters[graphql_name] = graphene.InputField(
+                    cls.FILTER_OBJECT_TYPES[op](OperatorAutoType, False, doc), description=doc
+                )
+
+            AutoType = type(
+                "_".join(parents), (graphene.InputObjectType, ), filters)
+            parent[parent_field] = graphene.InputField(
+                AutoType, description=parent_field)
+
+        return fields
+
+    @classmethod
     def filter(
         cls, info: ResolveInfo, query: Query, filters: 'FilterType'
     ) -> Query:
@@ -683,7 +765,6 @@ class FilterSet(graphene.InputObjectType):
 
         """
         context = info.context
-
         if isinstance(context, dict):
             context[cls._filter_aliases] = {}
         elif '__dict__' in context.__dir__():
@@ -697,11 +778,25 @@ class FilterSet(graphene.InputObjectType):
             ).format(type(context))
             warnings.warn(msg, RuntimeWarning)
 
-        query, sqla_filters = cls._translate_many_filter(info, query, filters)
-        if sqla_filters is not None:
-            query = query.filter(*sqla_filters)
-
-        return query
+        result = {
+            "__root__": {}
+        }
+        query = cls._translate_many_filter(
+            info=info,
+            query=query,
+            filters=filters,
+            join_by=and_,
+            parent="__root__",
+            result=result["__root__"],
+            parent_result=result,
+            model=cls.model,
+            parent_attr=None
+        )
+        print(result)
+        if not isinstance(result["__root__"], dict):
+            return query.filter(result["__root__"])
+        else:
+            return query
 
     @classmethod
     @lru_cache(maxsize=500)
@@ -737,104 +832,131 @@ class FilterSet(graphene.InputObjectType):
         raise KeyError('Operator not found "{}"'.format(graphql_field))
 
     @classmethod
-    def _translate_filter(
-        cls, info: ResolveInfo, query: Query, key: str, value: 'Any'
-    ) -> 'Tuple[Query, Any]':
-        """
-        Translate GraphQL to SQLAlchemy filters.
-
-        Args:
-            info: GraphQL resolve info.
-            query: SQLAlchemy query.
-            key: Filter key: model field, 'or', 'and', 'not', custom filter.
-            value: Filter value.
-
-        Returns:
-            SQLAlchemy clause.
-
-        """
-        if key in cls._custom_filters:
-            filter_name = key + '_filter'
-            with warnings.catch_warnings():
-                warnings.simplefilter('ignore', SAWarning)
-                clause = getattr(cls, filter_name)(info, query, value)
-                if isinstance(clause, tuple):
-                    query, clause = clause
-
-            return query, clause
-
-        if key == cls.GRAPHQL_EXPRESSION_NAMES[cls.AND]:
-            return cls._translate_many_filter(info, query, value, and_)
-
-        if key == cls.GRAPHQL_EXPRESSION_NAMES[cls.OR]:
-            return cls._translate_many_filter(info, query, value, or_)
-
-        if key == cls.GRAPHQL_EXPRESSION_NAMES[cls.NOT]:
-            return cls._translate_many_filter(
-                info, query, value, lambda *x: not_(and_(*x))
-            )
-
-        field, expression = cls._split_graphql_field(key)
-        filter_function = cls.FILTER_FUNCTIONS[expression]
-
-        try:
-            model_field = getattr(cls.model, field)
-        except AttributeError:
-            raise KeyError('Field not found: ' + field)
-
-        model_field_type = getattr(model_field, 'type', None)
-        is_enum = isinstance(model_field_type, sqltypes.Enum)
-        if is_enum and model_field_type.enum_class:
-            if isinstance(value, list):
-                value = [model_field_type.enum_class(v) for v in value]
-            else:
-                value = model_field_type.enum_class(value)
-
-        clause = filter_function(model_field, value)
-        return query, clause
-
-    @classmethod
     def _translate_many_filter(
         cls,
         info: ResolveInfo,
         query: Query,
         filters: 'Union[List[FilterType], FilterType]',
-        join_by: 'Callable' = None,
-    ) -> 'Tuple[Query, Any]':
+        join_by: 'Callable',
+        parent: 'String',
+        result: dict,
+        parent_result: dict,
+        model: 'sqlalchemy.ext.declarative.api.DeclarativeMeta',
+        parent_attr: 'Union[sqlalchemy.orm.attributes.InstrumentedAttribute, None]'
+    ) -> 'Query':
         """
-        Translate several filters.
+        Recursively translate filters.
 
         Args:
             info: GraphQL resolve info.
             query: SQLAlchemy query.
             filters: GraphQL filters.
             join_by: Join translated filters.
+            parent: The parent key.
+            result: The result dict.
+            parent_result: Parent for the result.
+            model: The model to translate.
+            parent_attr: The parent attribute (for relationships).
 
         Returns:
-            SQLAlchemy clause.
+            Query.
 
         """
-        result = []
+        join_by_map = {
+            "and": and_,
+            "or": or_,
+            "not": lambda *x: not_(and_(*x))
+        }
+        for key, value in filters.items():
 
-        # Filters from 'and', 'or', 'not'.
-        if isinstance(filters, list):
-            for f in filters:
-                query, local_filters = cls._translate_many_filter(
-                    info, query, f, and_
-                )
-                if local_filters is not None:
-                    result.append(local_filters)
+            if key in cls._custom_filters:
+                filter_name = key + '_filter'
+                with warnings.catch_warnings():
+                    warnings.simplefilter('ignore', SAWarning)
+                    clause = getattr(cls, filter_name)(info, query, value)
+                    if isinstance(clause, tuple):
+                        query, clause = clause
+                result[key] = clause
+                continue
 
-        else:
-            for k, v in filters.items():
-                query, r = cls._translate_filter(info, query, k, v)
-                if r is not None:
-                    result.append(r)
+            if key in ("and", "or", "not"):
+                result.setdefault(key, {})
+                if key in ("and", "or"):
+                    for op_key, op_filters in enumerate(value):
+                        result[key].setdefault(op_key, {})
+                        query = cls._translate_many_filter(
+                            info=info,
+                            query=query,
+                            filters=op_filters,
+                            join_by=and_,
+                            parent=op_key,
+                            result=result[key][op_key],
+                            parent_result=result[key],
+                            model=model,
+                            parent_attr=parent_attr
+                        )
+                    result[key] = join_by_map[key](
+                        *[v for v in result[key].values() if not isinstance(v, dict)])
+                else:
+                    query = cls._translate_many_filter(
+                        info=info,
+                        query=query,
+                        filters=value,
+                        join_by=join_by_map[key],
+                        parent=key,
+                        result=result[key],
+                        parent_result=result,
+                        model=model,
+                        parent_attr=parent_attr
+                    )
+                continue
 
+            field, expression = cls._split_graphql_field(key)
+            filter_function = cls.FILTER_FUNCTIONS[expression]
+
+            if isinstance(value, dict) and expression != "range":
+                result.setdefault(key, {})
+                inspected = inspection.inspect(model)
+                for relationship in inspected.relationships:
+                    if relationship.key == key:
+                        query = cls._translate_many_filter(
+                            info=info,
+                            query=query,
+                            filters=value,
+                            join_by=and_,
+                            parent=key,
+                            result=result[key],
+                            parent_result=result,
+                            model=relationship.mapper.class_,
+                            parent_attr=getattr(model, key)
+                        )
+                        break
+            else:
+                try:
+                    model_field = getattr(model, field)
+                except AttributeError:
+                    raise KeyError('Field not found: ' + field)
+
+                model_field_type = getattr(model_field, 'type', None)
+                is_enum = isinstance(model_field_type, sqltypes.Enum)
+                if is_enum and model_field_type.enum_class:
+                    if isinstance(value, list):
+                        value = [model_field_type.enum_class(v) for v in value]
+                    else:
+                        value = model_field_type.enum_class(value)
+
+                result[key] = filter_function(getattr(model, field), value)
+
+        # Join this level of filters and store under the parent key
         if not result:
-            return query, None
-
-        if join_by is None:
-            return query, result
-
-        return query, join_by(*result)
+            return query
+        if parent_attr is None:
+            parent_result[parent] = join_by(
+                *[v for v in result.values() if not isinstance(v, dict)])
+        elif parent_attr.property.uselist:
+            parent_result[parent] = parent_attr.any(join_by(
+                *[v for v in result.values() if not isinstance(v, dict)]))
+        else:
+            parent_result[parent] = parent_attr.has(join_by(
+                *[v for v in result.values() if not isinstance(v, dict)]))
+        return query

--- a/tests/graphql_objects.py
+++ b/tests/graphql_objects.py
@@ -11,7 +11,7 @@ from graphene_sqlalchemy_filter import FilterableConnectionField, FilterSet
 from tests import gqls_version
 
 # This module
-from .models import Article, Author, Group, Membership, User
+from .models import Article, Assignment, Author, Group, Membership, Task, User
 
 
 class BaseFilter(FilterSet):
@@ -35,6 +35,13 @@ USER_FILTER_FIELDS = {
     'balance': ['eq', 'ne', 'gt', 'lt', 'range', 'is_null'],
     'is_active': ['eq', 'ne'],
     'username_hybrid_property': ['eq', 'ne', 'in'],
+    'assignments': {
+        'task': {
+            'name': ['eq'],
+            'id': ['eq']
+        },
+        'active': ['eq']
+    }
 }
 
 
@@ -191,11 +198,35 @@ class ArticleConnection(Connection):
         node = ArticleNode
 
 
+class TaskNode(SQLAlchemyObjectType):
+    class Meta:
+        model = Task
+        interfaces = (graphene.relay.Node,)
+
+
+class TaskConnection(Connection):
+    class Meta:
+        node = TaskNode
+
+
+class AssignmentNode(SQLAlchemyObjectType):
+    class Meta:
+        model = Assignment
+        interfaces = (graphene.relay.Node,)
+
+
+class AssignmentConnection(Connection):
+    class Meta:
+        node = AssignmentNode
+
+
 class Query(graphene.ObjectType):
     field = MyFilterableConnectionField(UserConnection)
     all_groups = MyFilterableConnectionField(GroupConnection)
     all_authors = MyFilterableConnectionField(AuthorConnection)
     all_articles = MyFilterableConnectionField(ArticleConnection)
+    tasks = MyFilterableConnectionField(TaskConnection)
+    assignments =  MyFilterableConnectionField(AssignmentConnection)
 
 
 schema = graphene.Schema(query=Query)

--- a/tests/models.py
+++ b/tests/models.py
@@ -46,6 +46,7 @@ class User(Base):
     username = Column(String(50), nullable=False, unique=True, index=True)
     balance = Column(Integer, default=None)
     is_active = Column(Boolean, default=True)
+    assignments = relationship('Assignment', back_populates='user')
     if gqls_version >= (2, 2, 0):
         status = Column(Enum(StatusEnum), default=StatusEnum.offline)
 
@@ -106,3 +107,22 @@ class Article(Base):
     )
 
     author = relationship('Author', back_populates='articles')
+
+
+class Task(Base):
+    __tablename__ = 'task'
+
+    id = Column(Integer, primary_key=True)
+    name = Column(String(32))
+    assignments = relationship('Assignment', back_populates='task')
+
+
+class Assignment(Base):
+    __tablename__ = 'assignment'
+
+    task_id = Column(Integer, ForeignKey('task.id'), primary_key=True)
+    task = relationship('Task', back_populates='assignments')
+    user_id = Column(Integer, ForeignKey('user.user_id'), primary_key=True)
+    user = relationship('User', back_populates='assignments')
+
+    active = Column(Boolean)

--- a/tests/test_filter_set.py
+++ b/tests/test_filter_set.py
@@ -33,10 +33,11 @@ def test_default_filter_field_types():
     for model_field, operators in USER_FILTER_FIELDS.items():
         for op in operators:
             field = model_field
+            if op not in UserFilter.GRAPHQL_EXPRESSION_NAMES:
+                continue
             graphql_op = UserFilter.GRAPHQL_EXPRESSION_NAMES[op]
             if graphql_op:
                 field += filters.DELIMITER + graphql_op
-
             assert field in filter_fields, 'Field not found: ' + field
             assert isinstance(filter_fields[field], graphene.InputField)
             del filter_fields[field]
@@ -320,3 +321,16 @@ def test_sql_alchemy_wrong_column_types():
             class Meta:
                 model = models.User
                 fields = {'id': [...]}
+
+
+def test_generate_relationship_filter_field_names_concatenate_parents():
+    filter_fields = deepcopy(UserFilter._meta.fields)
+
+    assert filter_fields["assignments"].type._meta.name == "assignments"
+    assert getattr(filter_fields["assignments"].type, "and").type.of_type.of_type._meta.name == "assignments_and"
+    assert getattr(filter_fields["assignments"].type, "or").type.of_type.of_type._meta.name == "assignments_or"
+    assert getattr(filter_fields["assignments"].type, "not").type._meta.name == "assignments_not"
+    assert filter_fields["assignments"].type.task.type._meta.name == "assignments_task"
+    assert getattr(filter_fields["assignments"].type.task.type, "and").type.of_type.of_type._meta.name == "assignments_task_and"
+    assert getattr(filter_fields["assignments"].type.task.type, "or").type.of_type.of_type._meta.name == "assignments_task_or"
+    assert getattr(filter_fields["assignments"].type.task.type, "not").type._meta.name == "assignments_task_not"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -6,7 +6,7 @@ from graphene_sqlalchemy_filter.connection_field import (
     graphene_sqlalchemy_version_lt_2_1_2,
 )
 from tests.graphql_objects import schema
-from tests.models import Group, Membership, User
+from tests.models import Group, Membership, User, Task, Assignment
 from tests.utils import SQLAlchemyQueryCounter
 
 
@@ -80,6 +80,43 @@ def add_users_to_new_groups(session, users):
     session.bulk_save_objects(memberships, return_defaults=True)
     session.flush()
     return groups
+
+
+def add_tasks(session):
+    tasks = [
+        Task(name='Write code'),
+        Task(name='Write documentation'),
+        Task(name='Make breakfast'),
+    ]
+    session.bulk_save_objects(tasks, return_defaults=True)
+    session.flush()
+
+    return tasks
+
+
+def assign_users_to_tasks(session, users):
+    tasks = add_tasks(session)
+
+    assignments = [
+        Assignment(
+            user_id=users[0].id,
+            task_id=tasks[0].id,
+            active=True
+        ),
+        Assignment(
+            user_id=users[0].id,
+            task_id=tasks[1].id,
+            active=False
+        ),
+        Assignment(
+            user_id=users[1].id,
+            task_id=tasks[2].id,
+            active=True
+        )
+    ]
+    session.bulk_save_objects(assignments, return_defaults=True)
+    session.flush()
+    return assignments
 
 
 def test_response_without_filters(session):
@@ -322,3 +359,49 @@ def test_nested_response_with_recursive_model(session):
     assert len(group_0_sub_groups_edges) == 2
     sub_group_name = group_0_sub_groups_edges[0]['node']['name']
     assert sub_group_name == 'group_2'
+
+
+def test_relationship_filtering(session):
+    users = add_users(session)
+    assign_users_to_tasks(session, users)
+    session.commit()
+
+    request_string = """{
+        field(filters: {
+            assignments: {
+                 and: [
+                    {
+                         task: {
+                            name: "Write code",
+                        }
+                    },
+                    {
+                        active: true
+                    }
+                ]
+            }
+        }){
+            edges{
+                node{
+                    username
+                    assignments{
+                        edges{
+                            node{
+                                active
+                                task {
+                                    name
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }"""
+
+    execution_result = schema.execute(
+        request_string, context={'session': session}
+    )
+    assert len(execution_result.data["field"]["edges"]) == 1  # Only user_1 matches
+    assert execution_result.data["field"]["edges"][0]["node"]["username"] == "user_1"
+    assert len(execution_result.data["field"]["edges"][0]["node"]["assignments"]["edges"]) == 2

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -54,7 +54,6 @@ def test_enum(info_and_user_query):
     where_clause = query.whereclause
     ok = '"user".status = :status_1'
     assert str(where_clause) == ok
-
     assert where_clause.right.effective_value == models.StatusEnum.online
 
 
@@ -194,3 +193,39 @@ def test_complex_filters(info_and_user_query):
 
     str_query = str(query)
     assert str_query.lower().count('join') == 4, str_query
+
+
+def test_complex_relationship_filters(info_and_user_query):
+    info, user_query = info_and_user_query
+
+    filters = {
+            'not': {'is_active': True},
+            'or': [
+                {'is_admin': False},
+                {
+                    'assignments': {
+                        'or': [
+                            {
+                                'task': {'name': 'Write code'}
+                            },
+                            {'active': True}
+                        ]
+                    }
+                }
+            ]
+        }
+    query = UserFilter.filter(info, user_query, filters)
+
+    ok = (
+        '"user".is_active != true AND ("user".username != :username_1 OR (EXISTS (SELECT 1'
+        ' FROM "user", assignment'
+        ' WHERE "user".user_id = assignment.user_id AND ((EXISTS (SELECT 1'
+        ' FROM assignment'
+        ' WHERE "user".user_id = assignment.user_id AND (EXISTS (SELECT 1'
+        ' FROM task'
+        ' WHERE task.id = assignment.task_id AND task.name = :name_1)))) OR (EXISTS (SELECT 1'
+        ' FROM assignment'
+        ' WHERE "user".user_id = assignment.user_id AND assignment.active = true))))))'
+    )
+    where_clause = str(query.whereclause).replace('\n', '')
+    assert where_clause == ok


### PR DESCRIPTION
Great library! 

This PR proposes a generic solution for filtering over relationships.
For our project, we have to expose (almost) the entire database and creating custom filters for each relationship, especially when going over multiple levels, is just not feasible for us.

This is how it would work (Not functional, irrelevant bits are omitted):

**The models:**

```python
class User(Base):
    assignments = relationship('Assignment', back_populates='user')

class Task(Base):
    name = Column(String(32))
    assignments = relationship('Assignment', back_populates='task')

class Assignment(Base):
    task_id = Column(Integer, ForeignKey('task.id'), primary_key=True)
    task = relationship('Task', back_populates='assignments')
    user_id = Column(Integer, ForeignKey('user.user_id'), primary_key=True)
    user = relationship('User', back_populates='assignments')
    active = Column(Boolean)
```

**The filter:**

```python
class UserFilter(BaseFilter):
    class Meta:
        model = User
        fields = {
            'id': ['eq'],
            'assignments': {
                'task': {
                    'name': ['eq'],
                },
                'active': ['eq']
            }
        }
```

**GraphQL (All users with active assignments on a certain task):**

```
{
    user(filters: {
        assignments: {
            and: [
                {
                    task: {
                        name: "Write code"
                    }
                },
                {
                    active: true
                }
            ]
        }
    }){
        edges{
            node{
                username
            }
        }
    }
}
```